### PR TITLE
update node16 to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -117,5 +117,5 @@ outputs:
     description: 'Response body as string'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
it already runs fine on node20 for my usecases but gives nasty warning. node 20 has been forced by GitHub as of march this year https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

![Screenshot 2024-07-11 at 14 02 28](https://github.com/andrii-bodnar/crowdin-request-action/assets/559321/ee94ccb2-70c3-43cd-aa98-7711a904a37a)
